### PR TITLE
COMP: Fix build error in SkeletalRepresentationInitializerLogic

### DIFF
--- a/SkeletalRepresentationInitializer/Logic/vtkSlicerSkeletalRepresentationInitializerLogic.cxx
+++ b/SkeletalRepresentationInitializer/Logic/vtkSlicerSkeletalRepresentationInitializerLogic.cxx
@@ -555,7 +555,7 @@ void vtkSlicerSkeletalRepresentationInitializerLogic::HideNodesByNameByClass(con
 
 }
 
-int vtkSlicerSkeletalRepresentationInitializerLogic::InklingFlow(const std::string &filename, double dt, double smooth_amount, int max_iter, int freq_output, double threshold)
+int vtkSlicerSkeletalRepresentationInitializerLogic::InklingFlow(const std::string &filename, double dt, double smooth_amount, int max_iter, int freq_output, double /*threshold*/)
 {
     std::cout << filename << std::endl;
     std::cout << dt << std::endl;
@@ -578,7 +578,7 @@ int vtkSlicerSkeletalRepresentationInitializerLogic::InklingFlow(const std::stri
     double original_volume = mass_filter->GetVolume();
 
     int iter = 0;
-    double tolerance = 0.05;
+    // double tolerance = 0.05;
     double q = 1.0;
 
 //    while(q > tolerance && iter < max_iter)
@@ -668,7 +668,7 @@ int vtkSlicerSkeletalRepresentationInitializerLogic::InklingFlow(const std::stri
             double curr_N[3];
             N->GetTuple(i, curr_N);
             double curr_H = H->GetValue(i);
-            double curr_K = K->GetValue(i);
+            //double curr_K = K->GetValue(i);
             double curr_max = MC->GetValue(i);
             double curr_min = MinC->GetValue(i);
 

--- a/SkeletalRepresentationInitializer/Logic/vtkSlicerSkeletalRepresentationInitializerLogic.cxx
+++ b/SkeletalRepresentationInitializer/Logic/vtkSlicerSkeletalRepresentationInitializerLogic.cxx
@@ -30,6 +30,7 @@
 
 // VTK includes
 #include <vtkIntArray.h>
+#include <vtkMath.h>
 #include <vtkNew.h>
 #include <vtkCenterOfMass.h>
 #include <vtkObjectFactory.h>
@@ -457,7 +458,7 @@ int vtkSlicerSkeletalRepresentationInitializerLogic::ShowFittingEllipsoid(vtkPoi
     radii(1) = sqrt(radii(1));
     radii(2) = sqrt(radii(2));
 
-    double ellipsoid_volume = 4 / 3.0 * M_PI * radii(0) * radii(1) * radii(2);
+    double ellipsoid_volume = 4 / 3.0 * vtkMath::Pi() * radii(0) * radii(1) * radii(2);
     double volume_factor = pow(curr_volume / ellipsoid_volume, 1.0 / 3.0); 
     radii(0) *= volume_factor;
     radii(1) *= volume_factor;


### PR DESCRIPTION
This commit fixes error like the following:

vtkSlicerSkeletalRepresentationInitializerLogic.cxx(460):
error C2065: 'M_PI': undeclared identifier