### PR TITLE
Enh interpolate crest

### DIFF
--- a/SkeletalRepresentationRefiner/Logic/vtkSlicerSkeletalRepresentationInterpolater.h
+++ b/SkeletalRepresentationRefiner/Logic/vtkSlicerSkeletalRepresentationInterpolater.h
@@ -53,7 +53,7 @@ public:
 
     // Interpolate the spoke between start spoke (startS) and end spoke(endS) given the distance (d) from
     // the start spoke to the end.
-    void InterpolateMiddleSpoke(vtkSpoke* startS, vtkSpoke* endS, double d, vtkSpoke* interpolatedSpoke);
+    bool InterpolateMiddleSpoke(vtkSpoke* startS, vtkSpoke* endS, double d, vtkSpoke* interpolatedSpoke);
 
     // interpolate skeletal point
     // Input corner spokes with radius, direction and base point

--- a/SkeletalRepresentationRefiner/Logic/vtkSlicerSkeletalRepresentationRefinerLogic.cxx
+++ b/SkeletalRepresentationRefiner/Logic/vtkSlicerSkeletalRepresentationRefinerLogic.cxx
@@ -2044,7 +2044,7 @@ void vtkSlicerSkeletalRepresentationRefinerLogic::ParseCrest(const string &crest
     {
         int idxDir = i * 3; // Ux, Uy, Uz
 
-        vtkSmartPointer<vtkSpoke> crestSpoke = vtkSmartPointer<vtkSpoke>::New();
+        vtkSpoke* crestSpoke = new vtkSpoke;
         crestSpoke->SetRadius(spokeRadii->GetValue(i));
         double u[3];
         u[0] = spokeDirs->GetValue(idxDir+0); u[1] = spokeDirs->GetValue(idxDir+1); u[2] = spokeDirs->GetValue(idxDir+2);

--- a/SkeletalRepresentationRefiner/Logic/vtkSlicerSkeletalRepresentationRefinerLogic.h
+++ b/SkeletalRepresentationRefiner/Logic/vtkSlicerSkeletalRepresentationRefinerLogic.h
@@ -217,21 +217,6 @@ private:
                         int interpolationLevel,
                         int nRows, int nCols, std::vector<vtkSpoke*> &result);
 
-  // Note that the direction of du and dv depends on the quads defination, du pointing downward and dv pointing rightward
-  void ComputeDxDuTopRow(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes, int currentSpokeId,
-                        double *dxdu, double *dxdu1);
-  void ComputeDxDvTopRow(std::vector<vtkSpoke *> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
-                        int currentSpokeId, int nRows, int nCols, double *dxdv, double *dxdv1);
-  void ComputeDxDuBotRow(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
-                         int currentSpokeId, int nRows, int nCols, double *dxdu, double *dxdu1);
-  void ComputeDxDvBotRow(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
-                         int currentSpokeId, int nRows, int nCols, double *dxdv, double *dxdv1);
-  // input orient: true crest spoke is to the right of the corresponding interior spoke
-  void ComputeDxDv(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
-                         size_t crestSpokeId, size_t interiorSpokeId, bool orient, double *dxdvCrest, double *dxdvInterior);
-  void ComputeDxDu(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
-                         size_t crestSpokeId, size_t interiorSpokeId, size_t nextCrestId,
-                   double *dxduCrest, double *dxduInterior);
 private:
   std::string mTargetMeshFilePath;
   std::string mSrepFilePath;

--- a/SkeletalRepresentationRefiner/Logic/vtkSlicerSkeletalRepresentationRefinerLogic.h
+++ b/SkeletalRepresentationRefiner/Logic/vtkSlicerSkeletalRepresentationRefinerLogic.h
@@ -219,6 +219,11 @@ private:
                          int currentSpokeId, int nRows, int nCols, double *dxdu, double *dxdu1);
   void ComputeDxDvBotRow(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
                          int currentSpokeId, int nRows, int nCols, double *dxdv, double *dxdv1);
+  void ComputeDxDv(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
+                         size_t crestSpokeId, size_t interiorSpokeId, double *dxdvCrest, double *dxdvInterior);
+  void ComputeDxDu(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
+                         size_t crestSpokeId, size_t interiorSpokeId, size_t nextCrestId,
+                   double *dxduCrest, double *dxduInterior);
 private:
   std::string mTargetMeshFilePath;
   std::string mSrepFilePath;

--- a/SkeletalRepresentationRefiner/Logic/vtkSlicerSkeletalRepresentationRefinerLogic.h
+++ b/SkeletalRepresentationRefiner/Logic/vtkSlicerSkeletalRepresentationRefinerLogic.h
@@ -163,7 +163,7 @@ private:
 
   // Interpolate crest region and connect them with quads
   void ConnectImpliedCrest(int interpolationLevel, int nRows, int nCols,
-                           const std::string &crest, std::vector<vtkSpoke*> &interiorSpokes,
+                           const std::string &crest, std::vector<vtkSpoke*> &upSpokes,std::vector<vtkSpoke*> &downSpokes,
                            vtkPoints *pts, vtkCellArray *quads);
 
   // connect crest position
@@ -215,7 +215,8 @@ private:
 
   void InterpolateCrest(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
                         int interpolationLevel,
-                        int nRows, int nCols, std::vector<vtkSpoke*> &result);
+                        int nRows, int nCols,
+                        std::vector<vtkSpoke*> &crest, std::vector<vtkSpoke*> &interior);
 
 private:
   std::string mTargetMeshFilePath;

--- a/SkeletalRepresentationRefiner/Logic/vtkSlicerSkeletalRepresentationRefinerLogic.h
+++ b/SkeletalRepresentationRefiner/Logic/vtkSlicerSkeletalRepresentationRefinerLogic.h
@@ -207,6 +207,18 @@ private:
                            std::vector<vtkSpoke *> &neighborU,
                            std::vector<vtkSpoke *> &neighborV);
   void ParseCrest(const std::string &crestFileName, std::vector<vtkSpoke*> &crestSpokes);
+
+  void InterpolateCrest(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
+                        int interpolationLevel,
+                        int nRows, int nCols, std::vector<vtkSpoke*> &result);
+  void ComputeDxDuTopRow(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes, int currentSpokeId,
+                        double *dxdu, double *dxdu1);
+  void ComputeDxDvTopRow(std::vector<vtkSpoke *> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
+                        int currentSpokeId, int nRows, int nCols, double *dxdv, double *dxdv1);
+  void ComputeDxDuBotRow(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
+                         int currentSpokeId, int nRows, int nCols, double *dxdu, double *dxdu1);
+  void ComputeDxDvBotRow(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
+                         int currentSpokeId, int nRows, int nCols, double *dxdv, double *dxdv1);
 private:
   std::string mTargetMeshFilePath;
   std::string mSrepFilePath;

--- a/SkeletalRepresentationRefiner/Logic/vtkSlicerSkeletalRepresentationRefinerLogic.h
+++ b/SkeletalRepresentationRefiner/Logic/vtkSlicerSkeletalRepresentationRefinerLogic.h
@@ -220,7 +220,7 @@ private:
   void ComputeDxDvBotRow(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
                          int currentSpokeId, int nRows, int nCols, double *dxdv, double *dxdv1);
   void ComputeDxDv(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
-                         size_t crestSpokeId, size_t interiorSpokeId, double *dxdvCrest, double *dxdvInterior);
+                         size_t crestSpokeId, size_t interiorSpokeId, bool orient, double *dxdvCrest, double *dxdvInterior);
   void ComputeDxDu(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
                          size_t crestSpokeId, size_t interiorSpokeId, size_t nextCrestId,
                    double *dxduCrest, double *dxduInterior);

--- a/SkeletalRepresentationRefiner/Logic/vtkSlicerSkeletalRepresentationRefinerLogic.h
+++ b/SkeletalRepresentationRefiner/Logic/vtkSlicerSkeletalRepresentationRefinerLogic.h
@@ -206,6 +206,7 @@ private:
                            vtkSrep* input,
                            std::vector<vtkSpoke *> &neighborU,
                            std::vector<vtkSpoke *> &neighborV);
+  void ParseCrest(const std::string &crestFileName, std::vector<vtkSpoke*> &crestSpokes);
 private:
   std::string mTargetMeshFilePath;
   std::string mSrepFilePath;

--- a/SkeletalRepresentationRefiner/Logic/vtkSlicerSkeletalRepresentationRefinerLogic.h
+++ b/SkeletalRepresentationRefiner/Logic/vtkSlicerSkeletalRepresentationRefinerLogic.h
@@ -161,6 +161,11 @@ private:
                                  vtkPoints *foldCurvePts, vtkCellArray *foldCurveCell,
                                  std::vector<vtkSpoke*>& interpolated, std::vector<vtkSpoke*>& primary);
 
+  // Interpolate crest region and connect them with quads
+  void ConnectImpliedCrest(int interpolationLevel, int nRows, int nCols,
+                           const std::string &crest, std::vector<vtkSpoke*> &interiorSpokes,
+                           vtkPoints *pts, vtkCellArray *quads);
+
   // connect crest position
   void ConnectCrestRegion(int interpolationLevel, int nRows, int nCols,
                           const std::string &srepFileName,
@@ -211,6 +216,8 @@ private:
   void InterpolateCrest(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
                         int interpolationLevel,
                         int nRows, int nCols, std::vector<vtkSpoke*> &result);
+
+  // Note that the direction of du and dv depends on the quads defination, du pointing downward and dv pointing rightward
   void ComputeDxDuTopRow(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes, int currentSpokeId,
                         double *dxdu, double *dxdu1);
   void ComputeDxDvTopRow(std::vector<vtkSpoke *> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
@@ -219,6 +226,7 @@ private:
                          int currentSpokeId, int nRows, int nCols, double *dxdu, double *dxdu1);
   void ComputeDxDvBotRow(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
                          int currentSpokeId, int nRows, int nCols, double *dxdv, double *dxdv1);
+  // input orient: true crest spoke is to the right of the corresponding interior spoke
   void ComputeDxDv(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,
                          size_t crestSpokeId, size_t interiorSpokeId, bool orient, double *dxdvCrest, double *dxdvInterior);
   void ComputeDxDu(std::vector<vtkSpoke*> &crestSpoke, std::vector<vtkSpoke*> &interiorSpokes,

--- a/SkeletalRepresentationRefiner/Logic/vtkSpoke.cpp
+++ b/SkeletalRepresentationRefiner/Logic/vtkSpoke.cpp
@@ -224,6 +224,34 @@ double vtkSpoke::GetRSradPenalty(double stepSize)
     else return (abs(detRSrad)-1);
 }
 
+void vtkSpoke::SetDxdu(double *dxdu)
+{
+    m_dxdu[0] = dxdu[0];
+    m_dxdu[1] = dxdu[1];
+    m_dxdu[2] = dxdu[2];
+}
+
+void vtkSpoke::SetDxdv(double *dxdv)
+{
+    m_dxdv[0] = dxdv[0];
+    m_dxdv[1] = dxdv[1];
+    m_dxdv[2] = dxdv[2];
+}
+
+void vtkSpoke::GetDxdu(double *dxdu)
+{
+    dxdu[0] = m_dxdu[0];
+    dxdu[1] = m_dxdu[1];
+    dxdu[2] = m_dxdu[2];
+}
+
+void vtkSpoke::GetDxdv(double *dxdv)
+{
+    dxdv[0] = m_dxdv[0];
+    dxdv[1] = m_dxdv[1];
+    dxdv[2] = m_dxdv[2];
+}
+
 void vtkSpoke::ComputeDerivatives(std::vector<vtkSpoke*> neibors, bool isForward, double stepSize, // input
                                   double *dxdu, double *dSdu, double *drdu) // output
 {

--- a/SkeletalRepresentationRefiner/Logic/vtkSpoke.cpp
+++ b/SkeletalRepresentationRefiner/Logic/vtkSpoke.cpp
@@ -224,32 +224,11 @@ double vtkSpoke::GetRSradPenalty(double stepSize)
     else return (abs(detRSrad)-1);
 }
 
-void vtkSpoke::SetDxdu(double *dxdu)
+bool vtkSpoke::IsValid()
 {
-    m_dxdu[0] = dxdu[0];
-    m_dxdu[1] = dxdu[1];
-    m_dxdu[2] = dxdu[2];
-}
-
-void vtkSpoke::SetDxdv(double *dxdv)
-{
-    m_dxdv[0] = dxdv[0];
-    m_dxdv[1] = dxdv[1];
-    m_dxdv[2] = dxdv[2];
-}
-
-void vtkSpoke::GetDxdu(double *dxdu)
-{
-    dxdu[0] = m_dxdu[0];
-    dxdu[1] = m_dxdu[1];
-    dxdu[2] = m_dxdu[2];
-}
-
-void vtkSpoke::GetDxdv(double *dxdv)
-{
-    dxdv[0] = m_dxdv[0];
-    dxdv[1] = m_dxdv[1];
-    dxdv[2] = m_dxdv[2];
+    return !(std::isnan(mR) ||
+            std::isnan(mUx) || std::isnan(mUy) || std::isnan(mUz)
+            || std::isnan(mPx) || std::isnan(mPy) || std::isnan(mPz));
 }
 
 void vtkSpoke::ComputeDerivatives(std::vector<vtkSpoke*> neibors, bool isForward, double stepSize, // input

--- a/SkeletalRepresentationRefiner/Logic/vtkSpoke.h
+++ b/SkeletalRepresentationRefiner/Logic/vtkSpoke.h
@@ -71,10 +71,8 @@ public:
     // output rSrad penalty
     double GetRSradPenalty(double delta);
 
-    void SetDxdu(double *dxdu);
-    void SetDxdv(double *dxdv);
-    void GetDxdu(double *dxdu);
-    void GetDxdv(double *dxdv);
+    // return true if this spoke is valid
+    bool IsValid();
 
 private:
     void ComputeDerivatives(std::vector<vtkSpoke*> neibors, bool isForward, double stepSize, // input
@@ -87,8 +85,6 @@ private:
     double mUx;
     double mUy;
     double mUz;
-    double m_dxdu[3];
-    double m_dxdv[3];
     bool mIsForwardU, mIsForwardV;
     std::vector<vtkSpoke*> mNeighborsU;
     std::vector<vtkSpoke*> mNeighborsV;

--- a/SkeletalRepresentationRefiner/Logic/vtkSpoke.h
+++ b/SkeletalRepresentationRefiner/Logic/vtkSpoke.h
@@ -71,6 +71,11 @@ public:
     // output rSrad penalty
     double GetRSradPenalty(double delta);
 
+    void SetDxdu(double *dxdu);
+    void SetDxdv(double *dxdv);
+    void GetDxdu(double *dxdu);
+    void GetDxdv(double *dxdv);
+
 private:
     void ComputeDerivatives(std::vector<vtkSpoke*> neibors, bool isForward, double stepSize, // input
                             double *dxdu, double *dSdu, double *drdu);
@@ -82,6 +87,8 @@ private:
     double mUx;
     double mUy;
     double mUz;
+    double m_dxdu[3];
+    double m_dxdv[3];
     bool mIsForwardU, mIsForwardV;
     std::vector<vtkSpoke*> mNeighborsU;
     std::vector<vtkSpoke*> mNeighborsV;


### PR DESCRIPTION
This commit finishes the interpolation of crest region along & cross fold curve. The result (as attached) can be seen by clicking "Show implied boundary" button in Refiner module. Such interpolation is the prerequisite of better refinement which includes crest spokes and for now is only for visualization.

The upcoming commit would be the refinement algorithm incorporating crest interpolation.
![crest_interp](https://user-images.githubusercontent.com/32915994/62840254-8aecbc00-bc65-11e9-8266-5f30339a2fe3.png)
