### PR TITLE
ENH: added ui file and added options

### DIFF
--- a/SRepVisualizer/CMakeLists.txt
+++ b/SRepVisualizer/CMakeLists.txt
@@ -13,6 +13,7 @@ set(MODULE_PYTHON_SCRIPTS
 
 set(MODULE_PYTHON_RESOURCES
   Resources/Icons/${MODULE_NAME}.png
+  Resources/UI/SRepVisualizer.ui
   )
 
 #-----------------------------------------------------------------------------

--- a/SRepVisualizer/Resources/UI/SRepVisualizer.ui
+++ b/SRepVisualizer/Resources/UI/SRepVisualizer.ui
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ValveMoldCreator</class>
+ <widget class="qMRMLWidget" name="ValveMoldCreator">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>494</width>
+    <height>810</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="inputFileLabelFile">
+       <property name="text">
+        <string>Input File (Input header.xml or .m3d):</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="ctkPathLineEdit" name="inputHeaderFileSelector">
+       <property name="filters">
+        <set>ctkPathLineEdit::Files|ctkPathLineEdit::NoDot|ctkPathLineEdit::NoDotAndDotDot|ctkPathLineEdit::NoDotDot|ctkPathLineEdit::Readable</set>
+       </property>
+       <property name="nameFilters">
+        <stringlist>
+         <string>*.xml *.m3d</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Input Model:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="ctkPathLineEdit" name="inputModelFileSelector">
+       <property name="filters">
+        <set>ctkPathLineEdit::Files|ctkPathLineEdit::NoDot|ctkPathLineEdit::NoDotDot|ctkPathLineEdit::Readable</set>
+       </property>
+       <property name="nameFilters">
+        <stringlist>
+         <string>*.vtp *.vtk *.stl</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0" colspan="2">
+      <widget class="QPushButton" name="convertButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string>Convert the s-rep from SALT format to legacy</string>
+       </property>
+       <property name="text">
+        <string>Convert s-rep</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0" colspan="2">
+      <widget class="ctkCollapsibleButton" name="parametersCollapsibleButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Parameters for legacy m3d format</string>
+       </property>
+       <property name="collapsed">
+        <bool>true</bool>
+       </property>
+       <widget class="QWidget" name="formLayoutWidget_2">
+        <property name="geometry">
+         <rect>
+          <x>9</x>
+          <y>39</y>
+          <width>451</width>
+          <height>92</height>
+         </rect>
+        </property>
+        <layout class="QFormLayout" name="formLayout_3">
+         <item row="0" column="1">
+          <widget class="ctkSliderWidget" name="distSlider">
+           <property name="toolTip">
+            <string>Parameter used in transformation from legacy s-rep to new s-rep</string>
+           </property>
+           <property name="singleStep">
+            <double>0.010000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>0.600000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Set distance to expand fold curve</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>Output folder (Folder to save the new xml format):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="2">
+          <widget class="ctkPathLineEdit" name="outputFolderButton">
+           <property name="label">
+            <string/>
+           </property>
+           <property name="filters">
+            <set>ctkPathLineEdit::Dirs|ctkPathLineEdit::NoDot|ctkPathLineEdit::NoDotDot|ctkPathLineEdit::Readable</set>
+           </property>
+           <property name="options">
+            <set>ctkPathLineEdit::ShowDirsOnly</set>
+           </property>
+           <property name="nameFilters">
+            <stringlist extracomment="Select folder to save xml files"/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="3" column="0" colspan="2">
+      <widget class="QPushButton" name="applyButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string>Parse and visualize s-rep</string>
+       </property>
+       <property name="text">
+        <string>Visualize s-rep file</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QCheckBox" name="extendMedialAxisCheckbox">
+       <property name="layoutDirection">
+        <enum>Qt::LeftToRight</enum>
+       </property>
+       <property name="text">
+        <string>Visualize extended medial axis</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>qMRMLWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkCollapsibleButton</class>
+   <extends>QWidget</extends>
+   <header>ctkCollapsibleButton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkPathLineEdit</class>
+   <extends>QWidget</extends>
+   <header>ctkPathLineEdit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkSliderWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkSliderWidget.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/SRepVisualizer/SRepVisualizer.py
+++ b/SRepVisualizer/SRepVisualizer.py
@@ -473,7 +473,8 @@ class SRepVisualizerLogic(ScriptedLoadableModuleLogic):
             medial_model.SetAndObservePolyData(tri.GetOutput())
 
         if modelPath and os.path.exists(modelPath):
-            reader = vtk.vtkXMLPolyDataReader()
+            readerClass = self.getModelDataReader(modelPath)
+            reader = readerClass()
             reader.SetFileName(modelPath)
             reader.Update()
 
@@ -481,6 +482,16 @@ class SRepVisualizerLogic(ScriptedLoadableModuleLogic):
             modelNode = modelsLogic.AddModel(reader.GetOutput())
             modelNode.SetName("Model")
             modelNode.GetDisplayNode().SetOpacity(0.5)
+
+    def getModelDataReader(self, filename):
+        if filename.endswith(".vtp"):
+            return vtk.vtkXMLPolyDataReader
+        elif filename.endswith(".vtk"):
+            return vtk.vtkPolyDataReader
+        elif filename.endswith(".stl"):
+            return vtk.vtkSTLReader
+        else:
+            raise ValueError("Currently only .vtk, .vtp, and .stl model files are supported")
 
     def validateInputs(self, filename, dist, outputFolder):
         if not os.path.exists(filename):


### PR DESCRIPTION
- medial axis can be extended to object boundary depending on crest spokes
- additionally, the original model can be selected for loading


## UI

![image](https://user-images.githubusercontent.com/10195822/114615984-54561880-9c74-11eb-960c-589d081770a0.png)
