### PR TITLE
COMP: Simplify build-system re-using VTK::eigen

### DIFF
--- a/SRepInitializer/Logic/CMakeLists.txt
+++ b/SRepInitializer/Logic/CMakeLists.txt
@@ -1,5 +1,4 @@
 project(vtkSlicer${MODULE_NAME}ModuleLogic)
-find_package(Eigen3 REQUIRED CONFIG)
 
 set(KIT ${PROJECT_NAME})
 
@@ -19,7 +18,7 @@ set(${KIT}_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
   vtkSlicerMarkupsModuleMRML
   vtkSlicerAnnotationsModuleMRML
-  Eigen3::Eigen
+  VTK::eigen
   )
 
 #-----------------------------------------------------------------------------

--- a/SRepInitializer/Logic/vtkSlicerSRepInitializerLogic.cxx
+++ b/SRepInitializer/Logic/vtkSlicerSRepInitializerLogic.cxx
@@ -57,8 +57,9 @@
 #include <vtkAppendPolyData.h>
 #include <vtkConeSource.h>
 // Eigen includes
-#include <Eigen/Dense>
-#include <Eigen/Eigenvalues>
+#include <vtk_eigen.h>
+#include VTK_EIGEN(Dense)
+#include VTK_EIGEN(Eigenvalues)
 
 // STD includes
 #include <cassert>

--- a/SRepRefiner/Logic/CMakeLists.txt
+++ b/SRepRefiner/Logic/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(vtkSlicer${MODULE_NAME}ModuleLogic)
-find_package(Eigen3 REQUIRED CONFIG)
+
 set(KIT ${PROJECT_NAME})
 
 set(${KIT}_EXPORT_DIRECTIVE "VTK_SLICER_${MODULE_NAME_UPPER}_MODULE_LOGIC_EXPORT")
@@ -27,7 +27,7 @@ set(${KIT}_SRCS
 
 set(${KIT}_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
-  Eigen3::Eigen
+  VTK::eigen
   vtkSlicerMarkupsModuleMRML
   )
 

--- a/SRepRefiner/Logic/Spoke.cpp
+++ b/SRepRefiner/Logic/Spoke.cpp
@@ -18,8 +18,9 @@
 #include <math.h>
 #include <vtkMath.h>
 // Eigen includes
-#include <Eigen/Dense>
-#include <Eigen/Eigenvalues>
+#include <vtk_eigen.h>
+#include VTK_EIGEN(Dense)
+#include VTK_EIGEN(Eigenvalues)
 Spoke::Spoke(){}
 
 Spoke::Spoke(double radius, double px, double py, double pz, double ux, double uy, double uz)


### PR DESCRIPTION
This commit removes the explicitly dependency on an externally built
Eigen3 library and instead add a dependency to `VTK::eigen`.

This should address the build of the extension and its publication on the extension manager. Indeed, following https://github.com/Slicer/ExtensionsIndex/commit/93c9159e720ac09760e8c24998f658f0554da101 (`Archive Eigen extension because it is a utility extension that is not used anymore by any extensions`), the dependent extension responsible to build Eigen was removed.