### PR TITLE
COMP: Adjust Eigen includes and find_package

### DIFF
--- a/SRepCreator/Logic/CMakeLists.txt
+++ b/SRepCreator/Logic/CMakeLists.txt
@@ -1,5 +1,4 @@
 project(vtkSlicer${MODULE_NAME}ModuleLogic)
-find_package(Eigen3 REQUIRED CONFIG)
 
 set(KIT ${PROJECT_NAME})
 
@@ -15,7 +14,7 @@ set(${KIT}_SRCS
 
 set(${KIT}_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
-  Eigen3::Eigen
+  VTK::eigen
   vtkSlicerSRepModuleMRML
   vtkSlicerSRepModuleLogic
   )

--- a/SRepCreator/Logic/vtkSlicerSRepCreatorLogic.h
+++ b/SRepCreator/Logic/vtkSlicerSRepCreatorLogic.h
@@ -29,8 +29,9 @@
 #include <cstdlib>
 
 // Eigen includes
-#include <Eigen/Dense>
-#include <Eigen/Eigenvalues>
+#include <vtk_eigen.h>
+#include VTK_EIGEN(Dense)
+#include VTK_EIGEN(Eigenvalues)
 
 #include "vtkSlicerSRepCreatorModuleLogicExport.h"
 #include <vtkEllipticalSRep.h>


### PR DESCRIPTION
The find_package call failed to find Eigen when built against Slicer 5