### PR TITLE
Minor updates

### DIFF
--- a/SRepCreator/Logic/vtkSlicerSRepCreatorLogic.cxx
+++ b/SRepCreator/Logic/vtkSlicerSRepCreatorLogic.cxx
@@ -240,7 +240,10 @@ vtkSmartPointer<vtkPolyData> vtkSlicerSRepCreatorLogic::FlowSurfaceMesh(
   const size_t outputEveryNumIterations)
 {
   if (!model) {
-    return nullptr;
+    throw std::invalid_argument("Input model is nullptr");
+  }
+  if(!model->GetMesh()) {
+    throw std::invalid_argument("Input model does not have a mesh");
   }
 
   auto mesh = vtkSmartPointer<vtkPolyData>::New();

--- a/SRepCreator/Resources/UI/qSlicerSRepCreatorModuleWidget.ui
+++ b/SRepCreator/Resources/UI/qSlicerSRepCreatorModuleWidget.ui
@@ -163,6 +163,12 @@
          <string>vtkMRMLModelNode</string>
         </stringlist>
        </property>
+       <property name="addEnabled">
+        <bool>false</bool>
+       </property>
+       <property name="removeEnabled">
+        <bool>false</bool>
+       </property>
       </widget>
      </item>
     </layout>


### PR DESCRIPTION
Addresses two minor issues

- Should not be able to create a new model via the qMRMLNodeComboBox for the input of the SRepCreator
- Fixes crash when input of the SRepCreator is a model that has no underlying mesh.