### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,9 @@ project(SkeletalRepresentation)
 set(EXTENSION_HOMEPAGE "https://github.com/KitwareMedical/SlicerSkeletalRepresentation/blob/master/README.md")
 set(EXTENSION_CATEGORY "Shape Analysis")
 set(EXTENSION_CONTRIBUTORS "Zhiyuan Liu (University of North Carolina at Chapel Hill), Junpyo Hong (University of North Carolina at Chapel Hill), Stephen M. Pizer (University of North Carolina at Chapel Hill), Jared Vicory (Kitware, Inc.), Pablo Hernandez-Cerdan (Kitware, Inc.), Beatriz Paniagua (Kitware, Inc.), Jean-Christophe Fillion-Robin (Kitware, Inc.), Connor Bowley (Kitware, Inc.)")
-set(EXTENSION_DESCRIPTION "This extension handles skeletal representations of 3D data")
+set(EXTENSION_DESCRIPTION "This extension allows for the creation, refinement, and viewing of Skeletal representations (s-reps).")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/KitwareMedical/SlicerSkeletalRepresentation/master/img/SRep.png")
-set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/KitwareMedical/SlicerSkeletalRepresentation/master/img/VisualizationScreenshot.png")
+set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/KitwareMedical/SlicerSkeletalRepresentation/529b95bc6d5275297c68b7666772242abd65b897/VisualizationScreenshot.png")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies
 set(EXTENSION_BUILD_SUBDIRECTORY inner-build)
 


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.